### PR TITLE
remove provider.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Terraform configuration used to create the required AWS resources for integratin
 
 | Name      | Description | Type | Default | Required |
 | ----------- | ----------- | ----------- | ----------- | ----------- |
-| `account_id` | AWS Account ID number of the account in which to manage resources. | `number` | N/A | Yes |
-| `aws_region` | The region in which to manage resources.| `string` | N/A | Yes |
 | `environment` | The target environment name for deployment | `string` | `prod` | No |
 | `integration_type` | Spectral integration type (A unique phrase describing the integration) - Available values: `terraform`, `jira` and `gitlab` | `string` | N/A | Yes |
 | [`env_vars`](#env_vars) | Extendable object contains all required environment variables required for the integration. | `map(string)` | N/A | No |
@@ -83,8 +81,6 @@ This variable holds a collection of tags grouped by key representing its target 
 module "spectral_lambda_integration" {
   source                        = "github.com/SpectralOps/spectral-terraform-lambda-integration?ref=v1.0.2"
 
-  account_id                    = 111111111111
-  aws_region                    = "us-east-1"
   environment                   = "prod"
   integration_type              = "terraform"
   lambda_enable_logs            = true
@@ -121,6 +117,15 @@ module "spectral_lambda_integration" {
       Resource = "api_gateway"
     }
   }
+}
+```
+
+Don't forget to configure your provider:
+```tcl
+provider "aws" {
+  allowed_account_ids = ["11111111111"]
+  region = "us-east-1"
+  profile = "example-profile"
 }
 ```
 

--- a/examples/basic-gitlab-integration.tf
+++ b/examples/basic-gitlab-integration.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id       = 111111111111
-  aws_region       = "us-east-1"
   integration_type = "gitlab"
 
   env_vars = {

--- a/examples/basic-jira-integration.tf
+++ b/examples/basic-jira-integration.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id       = 111111111111
-  aws_region       = "us-east-1"
   integration_type = "jira"
 
   env_vars = {

--- a/examples/basic-terraform-integration.tf
+++ b/examples/basic-terraform-integration.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id       = 111111111111
-  aws_region       = "us-east-1"
   integration_type = "terraform"
 
   env_vars = {

--- a/examples/custom-lambda-settings.tf
+++ b/examples/custom-lambda-settings.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id       = 111111111111
-  aws_region       = "us-east-1"
   integration_type = "terraform"
 
   lambda_function_timeout     = 320

--- a/examples/enable-cloudwatch-logs-group.tf
+++ b/examples/enable-cloudwatch-logs-group.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id                    = 111111111111
-  aws_region                    = "us-east-1"
   integration_type              = "terraform"
   lambda_enable_logs            = true
   lambda_logs_retention_in_days = 10

--- a/examples/extended-tags.tf
+++ b/examples/extended-tags.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id       = 111111111111
-  aws_region       = "us-east-1"
   integration_type = "terraform"
 
   tags = {

--- a/examples/extra-env-vars.tf
+++ b/examples/extra-env-vars.tf
@@ -1,8 +1,6 @@
 module "spectral_lambda_integration" {
   source = "github.com/SpectralOps/spectral-terraform-lambda-integration"
 
-  account_id       = 111111111111
-  aws_region       = "us-east-1"
   integration_type = "terraform"
 
   env_vars = {

--- a/modules/lambda/lambda.tf
+++ b/modules/lambda/lambda.tf
@@ -1,7 +1,7 @@
 locals {
-  runtime                           = "nodejs14.x"
-  lambda_handler                    = "handler.app"
-  lambda_source_code_zip_path       = "${path.module}/source_code/${var.integration_type}/app.zip"
+  runtime                     = "nodejs14.x"
+  lambda_handler              = "handler.app"
+  lambda_source_code_zip_path = "${path.module}/source_code/${var.integration_type}/app.zip"
 }
 
 resource "aws_lambda_function" "spectral_scanner_lambda" {

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  region              = var.aws_region
-  allowed_account_ids = [var.account_id]
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,3 @@
-# General variables
-
-variable "aws_region" {
-  type        = string
-  description = "The region in which to manage resources."
-}
-
-variable "account_id" {
-  type        = string
-  description = "AWS Account ID number of the account in which to manage resources."
-}
-
 variable "integration_type" {
   type        = string
   description = "Spectral integration type (A unique phrase describing the integration) - Available values: `terraform`."

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,5 @@
+# General variables
+
 variable "integration_type" {
   type        = string
   description = "Spectral integration type (A unique phrase describing the integration) - Available values: `terraform`."


### PR DESCRIPTION
It is not recommended to define `provider.tf` in terraform modules.  
From the docs: https://developer.hashicorp.com/terraform/language/modules/develop/providers:  
> A module intended to be called by one or more other modules must not contain any provider blocks. A module containing its own provider configurations is not compatible with the for_each, count, and depends_on arguments that were introduced in Terraform v0.13.

For me it created a problem when I wanted to deploy this module with a custom aws_profile.  