### PR TITLE
Loose version constraints

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.3.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.37.0"
+      version = ">= 4.37.0"
     }
   }
 }


### PR DESCRIPTION
Currently, this module cannot be deployed by Terraform version 1.4.0+ due to the `~>` operator restricting the Terraform version to "1.3.x". 

Terraform's [best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#best-practices) recommend reusable modules not to do that:

> Reusable modules should constrain only their minimum allowed versions of Terraform and providers, such as `>= 0.12.0`. This helps avoid known incompatibilities, while allowing the user of the module flexibility to upgrade to newer versions of Terraform without altering the module.

So let's only define minimum versions here for both Terraform itself and the AWS provider. I guess the caller / root module will have to deal with any incompatibilities introduced then for flexibility reasons.

(I haven't been able to test this yet with the most recent versions, so it would be cool if you / CI could do that).