### PR TITLE
Run CI with --unpack

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,4 +16,4 @@ jobs:
         uses: spectralops/spectral-github-action@v3
         with:
           spectral-dsn: ${{ env.SPECTRAL_DSN }}
-          spectral-args: scan --ok --include-tags base,iac
+          spectral-args: scan --unpack --ok --include-tags base,iac

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,4 +16,4 @@ jobs:
         uses: spectralops/spectral-github-action@v3
         with:
           spectral-dsn: ${{ env.SPECTRAL_DSN }}
-          spectral-args: scan --unpack --ok --include-tags base,iac
+          spectral-args: scan --unpack --ok --engines secrets,iac


### PR DESCRIPTION
Since we hold the integrations source code that would be deployed to the lambda within this repo, we better perform the Spectral scan in our CI with the --unpack flag to detect if there are secrets within those source code files.