### PR TITLE
fix/bump node js runtime to 20.x

### DIFF
--- a/modules/lambda/lambda.tf
+++ b/modules/lambda/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  runtime                     = "nodejs14.x"
+  runtime                     = "nodejs20.x"
   lambda_source_code_zip_path = "${path.module}/source_code/${var.integration_type}/${var.lambda_source_code_filename}"
 }
 


### PR DESCRIPTION
while running terraform apply, AWS Lambda APIs returned an error: the nodejs 18.x environment is not supported and they recommended to upgrade to nodejs 20.x

This will unblock future depoloyements