### PR TITLE
Add read permissions for blacklist file

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -13,5 +13,6 @@ locals {
   # Please do not change or replace the 'frontend' suffix since there a logic in the bot based in it
   api_triggered_function_name = local.single_lambda_integration ? local.resource_name_pattern : "${local.resource_name_pattern}-frontend"
   # Merge user env vars with env vars which are not based on user input
-  env_vars = merge(var.env_vars, { HOME = "/tmp" })
+  env_vars           = merge(var.env_vars, { HOME = "/tmp" })
+  blacklist_file_arn = contains(keys(var.env_vars), "S3_BLACK_LIST_OBJECT_KEY") && contains(keys(var.env_vars), "S3_BLACK_LIST_BUCKET_NAME") ? "arn:aws:s3:::${var.env_vars.S3_BLACK_LIST_BUCKET_NAME}/${var.env_vars.S3_BLACK_LIST_OBJECT_KEY}" : null
 }

--- a/modules/role/role.tf
+++ b/modules/role/role.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "lambda_execution_role" {
 }
 
 data "aws_iam_policy_document" "s3_policy_document" {
-  count  = local.should_create_s3_policy ? 1 : 0
+  count = local.should_create_s3_policy ? 1 : 0
   statement {
     sid       = ""
     effect    = "Allow"

--- a/modules/role/role.tf
+++ b/modules/role/role.tf
@@ -1,5 +1,5 @@
 locals {
-  should_create_s3_policy = var.blacklist_object_arn != null && var.blacklist_object_arn != "" ? true : false
+  should_create_s3_policy = var.blacklist_object_arn != null && var.blacklist_object_arn != "" ? 1 : 0
 }
 
 
@@ -28,7 +28,7 @@ resource "aws_iam_role" "lambda_execution_role" {
 }
 
 data "aws_iam_policy_document" "s3_policy_document" {
-  count = local.should_create_s3_policy ? 1 : 0
+  count = local.should_create_s3_policy
   statement {
     sid       = ""
     effect    = "Allow"
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "s3_policy_document" {
 }
 
 resource "aws_iam_policy" "s3_iam_policy" {
-  count  = local.should_create_s3_policy ? 1 : 0
+  count  = local.should_create_s3_policy
   policy = data.aws_iam_policy_document.s3_policy_document[count.index].json
 
   tags = merge(
@@ -48,7 +48,7 @@ resource "aws_iam_policy" "s3_iam_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "s3_policy_attachment" {
-  count      = local.should_create_s3_policy ? 1 : 0
+  count      = local.should_create_s3_policy
   role       = aws_iam_role.lambda_execution_role.name
   policy_arn = aws_iam_policy.s3_iam_policy[count.index].arn
 }

--- a/modules/role/role.tf
+++ b/modules/role/role.tf
@@ -1,5 +1,5 @@
 locals {
-  should_create_s3_policy = var.blacklist_object_arn != null && var.blacklist_object_arn != "" ? 1 : 0
+  should_create_s3_policy = var.blacklist_object_arn != null ? 1 : 0
 }
 
 

--- a/modules/role/role.tf
+++ b/modules/role/role.tf
@@ -1,3 +1,8 @@
+locals {
+  should_create_s3_policy = var.blacklist_object_arn != null && var.blacklist_object_arn != "" ? true : false
+}
+
+
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     sid    = ""
@@ -20,6 +25,32 @@ resource "aws_iam_role" "lambda_execution_role" {
     var.global_tags,
     lookup(var.tags, "iam", {}),
   )
+}
+
+data "aws_iam_policy_document" "s3_policy_document" {
+  count  = local.should_create_s3_policy ? 1 : 0
+  statement {
+    sid       = ""
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = [var.blacklist_object_arn]
+  }
+}
+
+resource "aws_iam_policy" "s3_iam_policy" {
+  count  = local.should_create_s3_policy ? 1 : 0
+  policy = data.aws_iam_policy_document.s3_policy_document[count.index].json
+
+  tags = merge(
+    var.global_tags,
+    lookup(var.tags, "iam", {}),
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "s3_policy_attachment" {
+  count      = local.should_create_s3_policy ? 1 : 0
+  role       = aws_iam_role.lambda_execution_role.name
+  policy_arn = aws_iam_policy.s3_iam_policy[count.index].arn
 }
 
 data "aws_iam_policy_document" "secrets_policy_document" {

--- a/modules/role/variables.tf
+++ b/modules/role/variables.tf
@@ -9,6 +9,12 @@ variable "secrets_arns" {
   default     = []
 }
 
+variable "blacklist_object_arn" {
+  description = "Arn of the blacklist file"
+  type        = string
+  default     = null
+}
+
 variable "global_tags" {
   type        = map(string)
   description = "A list of tags to apply on all newly created resources."

--- a/shared.tf
+++ b/shared.tf
@@ -30,4 +30,5 @@ module "lambda_role" {
   tags                            = var.tags
   global_tags                     = var.global_tags
   multiple_lambda_integration     = local.multiple_lambda_integration
+  blacklist_object_arn            = local.blacklist_file_arn
 }


### PR DESCRIPTION
Currently supported only in GitHub bot.

When S3_BLACK_LIST_BUCKET_NAME and S3_BLACK_LIST_OBJECT_KEY env vars are specified - we should add a read permission to the blacklist file sitting in S3.
We are allowing GetObject permission for this file's arn specifically.